### PR TITLE
pointillism rendered account-takeover

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # graphviz-models
 Conceptual models developed as part of my research work with the help of the great Graphviz library (https://www.graphviz.org).
+
+
+![account-takeover](https://pointillism.io/trevorgrayson/Graphviz-Models/blob/master/Dictionary/account-takeover.gv)


### PR DESCRIPTION
You can use https://pointillism.io URLs and get rid of rendering and checking in your own images!  The links work in <img> tags anywhere you want them.

PROTIP:  You can also display your images in your repo's documentation -- like in README.md.  I've implemented account-takeover for you.  Hope this helps.

Make sure your documentation stays up to date with pointillism.